### PR TITLE
Fix small error on addon unregister

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -48,7 +48,7 @@ def unregister():
     from . import ui
     from . import operator
     prop.unregister()
-    operator.register()
+    operator.unregister()
     ui.unregister()
 
 if __name__ == '__main__':


### PR DESCRIPTION
It was running `register` instead of `unregister`, raising errors.